### PR TITLE
Added optional debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # "Cmd Trigger" Plugin
 
 Example config.json with custom delay (in ms) to turn off the switch:
@@ -11,7 +10,7 @@ Example config.json with custom delay (in ms) to turn off the switch:
           "command":   "echo Hello World",
           "delay":   "10000",
           "execAfterDelay": false
-        }   
+        }
     ]
 
 ```
@@ -24,7 +23,8 @@ Example config.json with stateful switch:
 	        "accessory": "CmdTrigger",
 	        "name":      "Stafeful Switch",
 	        "command":   "dummy",
-	        "stateful":   "true",
+	        "stateful":   true,
+	        "debug":      false
 	    }
     ]
 ```
@@ -36,9 +36,7 @@ You can also use this plugin as fakeswitch with custom delay, or as a stateful s
 This plugin was created by extending homebridge-dummy plugin: https://github.com/nfarina/homebridge-dummy.
 
 # Installation instructions
+
 ```
 $: npm -g install homebridge-cmdtrigger
 ```
-
-
-

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ function CmdTrigger(log, config) {
   this.command = config.command ? config.command : "echo HelloWorld";
   this.stateful = config.stateful;
   this.delay = config.delay ? config.delay : 800;
+  this.debug = config.debug ? config.debug : false;
   this.execAfterDelay = config.execAfterDelay
   this._service = new Service.Switch(this.name);
   
@@ -48,8 +49,18 @@ CmdTrigger.prototype._setOn = function(on, callback) {
   if (on && !this.stateful) {
     if (!this.execAfterDelay) {
       //Execute command from config file and turn switch off again after configured delay
-      exec(this.command);
-      this.log("Command executed: '" + this.command + "'");
+      this.log("Executing command: '" + this.command + "'");
+      if(debug){
+        exec(this.command, (err, stdout, stderr) => {
+            if (err) {
+                this.log(err);
+                return;
+            }
+            this.log(stdout);
+        });
+      } else {
+        exec(this.command);
+      }
       setTimeout(function() {
         this._service.setCharacteristic(Characteristic.On, false);
       }.bind(this), this.delay);
@@ -57,8 +68,18 @@ CmdTrigger.prototype._setOn = function(on, callback) {
     else{
       //Execute command after configured delay and turn switch off again
       setTimeout(function() {
-        exec(this.command);
-        this.log("Command executed: '" + this.command + "'");
+        this.log("Executing command: '" + this.command + "'");
+        if(debug){
+            exec(this.command, (err, stdout, stderr) => {
+                if (err) {
+                    this.log(err);
+                    return;
+                }
+                this.log(stdout);
+            });
+        } else {
+            exec(this.command);
+        }
         this._service.setCharacteristic(Characteristic.On, false);
       }.bind(this), this.delay);
     }


### PR DESCRIPTION
Add `"debug": true` to config, to print out cmd response to homebridge log (optional).
Helped me to debug some access privilege issues …